### PR TITLE
large bit vector fix

### DIFF
--- a/src/bitwise/fixnum.rs
+++ b/src/bitwise/fixnum.rs
@@ -241,7 +241,7 @@ impl<T> fmt::Display for Fixnum<T>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for i in 0..T::bitwidth() {
-            try!(write!(f, "{}", if self.get(i as Index) { 1 } else { 0 }));
+            write!(f, "{}", if self.get(i as Index) { 1 } else { 0 })?;
         }
         Ok(())
     }

--- a/src/bitwise/sparse_one_nnd.rs
+++ b/src/bitwise/sparse_one_nnd.rs
@@ -81,7 +81,9 @@ impl From<BitString> for SparseOneNnd {
 }
 impl RankBit for SparseOneNnd {
     fn rank_one(&self, index: Index) -> Rank {
-        let large_index = (index / LARGE_SIZE as Index) as usize;
+        //let large_index = (index / LARGE_SIZE as Index) as usize;
+        let large_index = ((index / LARGE_SIZE as Index) as usize)
+             .min(self.larges.len() - 1); 
         let large_base = &self.larges[large_index];
         // let large_offset = large_index as Index * LARGE_SIZE as Index;
 
@@ -118,9 +120,12 @@ impl SelectOne for SparseOneNnd {
         let rank = rank - 1;
 
         //
+        //let i = self.larges
+            //.binary_search_by_key(&rank, |e| e.rank as Rank)
+            //.unwrap_or_else(|i| i - 1);
         let i = self.larges
-            .binary_search_by_key(&rank, |e| e.rank as Rank)
-            .unwrap_or_else(|i| i - 1);
+             .binary_search_by_key(&rank, |e| e.rank as Rank)
+             .unwrap_or_else(|i| i.saturating_sub(1));
         let large_base = &self.larges[i];
         let large_index = i as Index * LARGE_SIZE as Index;
         let middle_rank = rank - large_base.rank as Rank;
@@ -171,17 +176,16 @@ impl ops::ExternalByteSize for SparseOneNnd {
     }
 }
 
-#[derive(Debug, Clone)]
-struct Base<T> {
+#[derive(Debug, Clone, Copy)]        
+struct Base<T: Copy> {
     small_index: T,
-    rank: T,
+    rank:        T,
 }
-impl<T> Base<T> {
+
+impl<T: Copy> Base<T> {                
+    #[inline]
     fn new(small_index: T, rank: T) -> Self {
-        Base {
-            small_index: small_index,
-            rank: rank,
-        }
+        Base { small_index, rank }
     }
 }
 

--- a/src/bitwise/sparse_one_nnd.rs
+++ b/src/bitwise/sparse_one_nnd.rs
@@ -87,8 +87,11 @@ impl RankBit for SparseOneNnd {
         let large_base = &self.larges[large_index];
         // let large_offset = large_index as Index * LARGE_SIZE as Index;
 
-        let middle_index = (index / MIDDLE_SIZE as Index) as usize;
-        let middle_base = &self.middles[middle_index];
+        //let middle_index = (index / MIDDLE_SIZE as Index) as usize;
+        let middle_index = ((index / MIDDLE_SIZE as Index) as usize)
+            .min(self.middles.len() - 1);
+        //let middle_base = &self.middles[middle_index];
+        let middle_base  = &self.middles[middle_index];
         let middle_offset = middle_index as Index * MIDDLE_SIZE as Index;
 
         let mut small_index = large_base.small_index as usize + middle_base.small_index as usize;
@@ -130,8 +133,10 @@ impl SelectOne for SparseOneNnd {
         let large_index = i as Index * LARGE_SIZE as Index;
         let middle_rank = rank - large_base.rank as Rank;
 
+        //let middle_start = i * MIDDLE_COUNT;
         let middle_start = i * MIDDLE_COUNT;
-        let middle_end = ::std::cmp::min(self.middles.len(), middle_start + MIDDLE_COUNT);
+        //let middle_end = ::std::cmp::min(self.middles.len(), middle_start + MIDDLE_COUNT);
+        let middle_end   = (middle_start + MIDDLE_COUNT).min(self.middles.len());
         let middles = &self.middles[middle_start..middle_end];
         {
             let i = middles.binary_search_by_key(&middle_rank, |e| e.rank as Rank)

--- a/src/bitwise/sparse_one_nnd.rs
+++ b/src/bitwise/sparse_one_nnd.rs
@@ -81,16 +81,11 @@ impl From<BitString> for SparseOneNnd {
 }
 impl RankBit for SparseOneNnd {
     fn rank_one(&self, index: Index) -> Rank {
-        //let large_index = (index / LARGE_SIZE as Index) as usize;
         let large_index = ((index / LARGE_SIZE as Index) as usize)
              .min(self.larges.len() - 1); 
         let large_base = &self.larges[large_index];
-        // let large_offset = large_index as Index * LARGE_SIZE as Index;
-
-        //let middle_index = (index / MIDDLE_SIZE as Index) as usize;
         let middle_index = ((index / MIDDLE_SIZE as Index) as usize)
             .min(self.middles.len() - 1);
-        //let middle_base = &self.middles[middle_index];
         let middle_base  = &self.middles[middle_index];
         let middle_offset = middle_index as Index * MIDDLE_SIZE as Index;
 
@@ -122,10 +117,6 @@ impl SelectOne for SparseOneNnd {
         }
         let rank = rank - 1;
 
-        //
-        //let i = self.larges
-            //.binary_search_by_key(&rank, |e| e.rank as Rank)
-            //.unwrap_or_else(|i| i - 1);
         let i = self.larges
              .binary_search_by_key(&rank, |e| e.rank as Rank)
              .unwrap_or_else(|i| i.saturating_sub(1));
@@ -133,9 +124,7 @@ impl SelectOne for SparseOneNnd {
         let large_index = i as Index * LARGE_SIZE as Index;
         let middle_rank = rank - large_base.rank as Rank;
 
-        //let middle_start = i * MIDDLE_COUNT;
         let middle_start = i * MIDDLE_COUNT;
-        //let middle_end = ::std::cmp::min(self.middles.len(), middle_start + MIDDLE_COUNT);
         let middle_end   = (middle_start + MIDDLE_COUNT).min(self.middles.len());
         let middles = &self.middles[middle_start..middle_end];
         {

--- a/src/bitwise/sparse_one_nnd.rs
+++ b/src/bitwise/sparse_one_nnd.rs
@@ -15,7 +15,7 @@ const LARGE_SIZE: usize = MIDDLE_SIZE * MIDDLE_COUNT;
 pub struct SparseOneNnd {
     smalles: Vec<u8>,
     middles: Vec<Base<u16>>,
-    larges: Vec<Base<u32>>,
+    larges: Vec<Base<u64>>,
 }
 impl SparseOneNnd {
     fn from_one_indices<I>(iter: I) -> Self
@@ -41,7 +41,7 @@ impl SparseOneNnd {
 
                 if next_small_i % LARGE_SIZE == 0 {
                     large_prev = Base::new(small_base, rank);
-                    larges.push(Base::new(large_prev.small_index as u32, large_prev.rank as u32));
+                    larges.push(Base::new(large_prev.small_index as u64, large_prev.rank as u64));
                 }
                 if next_small_i % MIDDLE_SIZE == 0 {
                     middles.push(Base::new((small_base - large_prev.small_index) as u16,
@@ -167,7 +167,7 @@ impl ops::ExternalByteSize for SparseOneNnd {
     fn external_byte_size(&self) -> u64 {
         self.smalles.len() as u64 +
         self.middles.len() as u64 * std::mem::size_of::<Base<u16>>() as u64 +
-        self.larges.len() as u64 * std::mem::size_of::<Base<u32>>() as u64
+        self.larges.len() as u64 * std::mem::size_of::<Base<u64>>() as u64
     }
 }
 

--- a/src/bitwise/string.rs
+++ b/src/bitwise/string.rs
@@ -51,11 +51,16 @@ impl<N> BitString<N>
         self.fixnums[base as usize].set(offset, bit);
     }
     pub fn push(&mut self, bit: Bit) {
+        
+        //let (base, offset) = Self::base_and_offset(self.len);
+        let (base, offset) = Self::base_and_offset(self.len);
+        //while self.fixnums.len() <= base as usize {
+            //self.fixnums.push(Fixnum::zero());
+        //}
+        while self.fixnums.len() <= base as usize {
+            self.fixnums.push(Fixnum::zero());
+        }
         if bit {
-            let (base, offset) = Self::base_and_offset(self.len);
-            while self.fixnums.len() <= base as usize {
-                self.fixnums.push(Fixnum::zero());
-            }
             self.fixnums[base as usize].set(offset, bit);
         }
         self.len += 1;

--- a/src/bitwise/string.rs
+++ b/src/bitwise/string.rs
@@ -51,12 +51,7 @@ impl<N> BitString<N>
         self.fixnums[base as usize].set(offset, bit);
     }
     pub fn push(&mut self, bit: Bit) {
-        
-        //let (base, offset) = Self::base_and_offset(self.len);
         let (base, offset) = Self::base_and_offset(self.len);
-        //while self.fixnums.len() <= base as usize {
-            //self.fixnums.push(Fixnum::zero());
-        //}
         while self.fixnums.len() <= base as usize {
             self.fixnums.push(Fixnum::zero());
         }
@@ -71,10 +66,10 @@ impl<N> BitString<N>
     pub fn shrink_to_fit(&mut self) {
         self.fixnums.shrink_to_fit();
     }
-    pub fn iter(&self) -> Iter<N> {
+    pub fn iter(&self) -> Iter<'_,N> {
         Iter::new(self)
     }
-    pub fn one_indices(&self) -> OneIndices<N> {
+    pub fn one_indices(&self) -> OneIndices<'_,N> {
         OneIndices::new(self)
     }
     pub fn as_fixnums(&self) -> &[Fixnum<N>] {
@@ -222,7 +217,7 @@ impl<N> fmt::Display for BitString<N>
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for b in self.iter() {
-            try!(write!(f, "{}", if b { 1 } else { 0 }))
+            write!(f, "{}", if b { 1 } else { 0 })?
         }
         Ok(())
     }

--- a/src/tree/balanced_parens/parentheses.rs
+++ b/src/tree/balanced_parens/parentheses.rs
@@ -109,35 +109,29 @@ impl<N> Parens<N>
                 .unwrap_or_else(|| {
                     let pioneers = self.pioneers.as_ref().unwrap();
                     let open_pioneer = pioneers.pred(index);
-                    //assert_eq!(base, open_pioneer / BLOCK_SIZE);
-                    //let level = b.relative_level(open_pioneer % BLOCK_SIZE, offset);
                     let open_block = open_pioneer / BLOCK_SIZE;
                     let level = if open_block == base {
                          b.relative_level(open_pioneer % BLOCK_SIZE, offset)
                      } else {
-                        /*  we entered the next block – recompute `relative_level`
-                         *  using its Fixnum                                                   */
                          let next_fix = &self.bits.as_fixnums()[open_block as usize];
                          next_fix.relative_level(open_pioneer % BLOCK_SIZE, 0) +    // inner lvl
                          b.relative_level(0, offset)                                // this block
                      };
 
                     let close_pioneer = pioneers.get_close(open_pioneer);
-                    //let close_block = &self.bits.as_fixnums()[(close_pioneer / BLOCK_SIZE) as usize];
-                    //let local_close_index = close_block.far_child(close_pioneer % BLOCK_SIZE, level);
                     let close_block_idx = (close_pioneer / BLOCK_SIZE) as usize;
                     let fixnums = self.bits.as_fixnums();
                     let close_fix = if close_block_idx < fixnums.len() {
                          &fixnums[close_block_idx]
                     } else {
                          /*  Pair crosses past the end (degenerate last word with
-                          *  only opens) – fall back to a linear scan.            */
+                          *  only opens) – fall back to a linear scan. */
                         let mut lvl = 0;
                         for i in index + 1 .. self.bits.len() {
                             if self.bits.get(i) == Some(OPEN) { lvl += 1 } else if lvl == 0 { return i }
                             else { lvl -= 1 }
                         }
-                    unreachable!("balanced parentheses guarantee a close exists");
+                        unreachable!("balanced parentheses guarantee a close exists");
                     };
                     let local_close_index =
                          close_fix.far_child(close_pioneer % BLOCK_SIZE, level);

--- a/src/tree/balanced_parens/parentheses.rs
+++ b/src/tree/balanced_parens/parentheses.rs
@@ -109,14 +109,38 @@ impl<N> Parens<N>
                 .unwrap_or_else(|| {
                     let pioneers = self.pioneers.as_ref().unwrap();
                     let open_pioneer = pioneers.pred(index);
-                    assert_eq!(base, open_pioneer / BLOCK_SIZE);
-                    let level = b.relative_level(open_pioneer % BLOCK_SIZE, offset);
+                    //assert_eq!(base, open_pioneer / BLOCK_SIZE);
+                    //let level = b.relative_level(open_pioneer % BLOCK_SIZE, offset);
+                    let open_block = open_pioneer / BLOCK_SIZE;
+                    let level = if open_block == base {
+                         b.relative_level(open_pioneer % BLOCK_SIZE, offset)
+                     } else {
+                        /*  we entered the next block – recompute `relative_level`
+                         *  using its Fixnum                                                   */
+                         let next_fix = &self.bits.as_fixnums()[open_block as usize];
+                         next_fix.relative_level(open_pioneer % BLOCK_SIZE, 0) +    // inner lvl
+                         b.relative_level(0, offset)                                // this block
+                     };
 
                     let close_pioneer = pioneers.get_close(open_pioneer);
-                    let close_block =
-                        &self.bits.as_fixnums()[(close_pioneer / BLOCK_SIZE) as usize];
+                    //let close_block = &self.bits.as_fixnums()[(close_pioneer / BLOCK_SIZE) as usize];
+                    //let local_close_index = close_block.far_child(close_pioneer % BLOCK_SIZE, level);
+                    let close_block_idx = (close_pioneer / BLOCK_SIZE) as usize;
+                    let fixnums = self.bits.as_fixnums();
+                    let close_fix = if close_block_idx < fixnums.len() {
+                         &fixnums[close_block_idx]
+                    } else {
+                         /*  Pair crosses past the end (degenerate last word with
+                          *  only opens) – fall back to a linear scan.            */
+                        let mut lvl = 0;
+                        for i in index + 1 .. self.bits.len() {
+                            if self.bits.get(i) == Some(OPEN) { lvl += 1 } else if lvl == 0 { return i }
+                            else { lvl -= 1 }
+                        }
+                    unreachable!("balanced parentheses guarantee a close exists");
+                    };
                     let local_close_index =
-                        close_block.far_child(close_pioneer % BLOCK_SIZE, level);
+                         close_fix.far_child(close_pioneer % BLOCK_SIZE, level);
 
                     let close_index = (close_pioneer / BLOCK_SIZE * BLOCK_SIZE) + local_close_index;
                     close_index

--- a/src/tree/traversal/byte_lines.rs
+++ b/src/tree/traversal/byte_lines.rs
@@ -4,7 +4,7 @@ use word::DepthFirstTraversal;
 
 pub struct ByteLines<R> {
     reader: io::Split<R>,
-    on_error: Box<Fn(io::Error)>,
+    on_error: Box<dyn Fn(io::Error)>,
 }
 impl<R> ByteLines<R>
     where R: io::BufRead


### PR DESCRIPTION
Hi @sile,

I am using this balanced parenthesis for large scale binary tree analysis for biology but for > 192000 parenthesis, there will always be some error:

thread 'main' panicked at /Users/jianshuzhao/.cargo/git/checkouts/succ-546d816ac76cfccd/a0cb247/src/tree/balanced_parens/parentheses.rs:117:26:
index out of bounds: the len is 1 but the index is 1


I noticed that for large trees, there are some problems with respect to the bit encodings (u64 should be used but not u32), I just fix it and let me know your comments. Large tree test showed that it worked well. 

Thanks,
Jianshu